### PR TITLE
【サーバサイド】商品情報編集

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -82,3 +82,13 @@ $(function(){
     $('#salesProfit').text(`¥${salesProfit}`);
   })
 });
+
+$(document).ready(function(){
+  if ($('.price-validation')) $('.price-validation').remove();
+  var price = $('#item_price').val();
+
+  const salesCommission = Math.ceil(price * 0.1)
+  const salesProfit = Math.floor(price - salesCommission)
+  $('#salesCommission').text(`¥${salesCommission}`);
+  $('#salesProfit').text(`¥${salesProfit}`);
+});

--- a/app/views/items/_itemForm.html.haml
+++ b/app/views/items/_itemForm.html.haml
@@ -9,25 +9,25 @@
         #ImageBox
           .ImageBox__show
             #previews
+              %label{for: "item_images_attributes_#{@item.images.count}_src", class: 'ImageBox__inputLabel', id: 'label-box-0'}
+                .ImageBox__inputLabel--visible
+                  = icon('fas', 'camera', class: "ImageBox__inputLabel--icon")
+                  %p.ImageBox__inputLabel--hwToUp ファイルを選択
               - if @item.persisted?
                 - @item.images.each_with_index do |image, i|
                   .ImageBox__preview{data: {index: i}}
                     = image_tag image.src.url, height: '100', width: '100', data: {index: i}
                     .ImageBox__remove 削除
-              %label{for: "item_images_attributes_#{@item.images.count}_src", class: 'ImageBox__inputLabel', id: 'label-box-0'}
-                .ImageBox__inputLabel--visible
-                  = icon('fas', 'camera', class: "ImageBox__inputLabel--icon")
-                  %p.ImageBox__inputLabel--hwToUp ファイルを選択
           .ImageBox__hidden
+            - if @item.persisted?
+              .ImageBox__fileGroup{data: {index: @item.images.count}}
+                = file_field_tag :src, name: "item[images_attributes][#{@item.images.count}][src]", class: 'ImageBox__file', id: "item_images_attributes_#{@item.images.count}_src"
             = f.fields_for :images do |image|
               .ImageBox__fileGroup{data: {index: image.index}}
                 = image.file_field :src, class: 'ImageBox__file', id: 'item_images_attributes_0_src'
                 %br/
               - if @item.persisted?
-                = image.check_box :_destroy, {data:{index: image.index}}, class: 'hidden-destroy'
-            - if @item.persisted?
-              .ImageBox__fileGroup{data: {index: @item.images.count}}
-                = file_field_tag :src, name: "item[images_attributes][#{@item.images.count}][src]", class: 'ImageBox__file', id: "item_images_attributes_#{@item.images.count}_src"
+                = image.check_box :_destroy, {data:{index: image.index}, class: 'hidden-destroy'}
     %hr/
     .FormBlock
       .FormBlock__content
@@ -105,7 +105,7 @@
             = f.number_field :price, placeholder: "0", required: true, min: 300, max: 9999999, class: "FormBox__short"
       .FormBlock__calc
         .FormBlock__calc--left
-          販売手数料（10%）
+          販売手数料（10％）
         .FormBlock__calc--right#salesCommission
           ー
       %hr.short/
@@ -115,7 +115,10 @@
         .FormBlock__calc--right#salesProfit
           ー
     .FormBlock__btn
-      = f.submit "出品する", class: "FormBlock__btn--market"
+      - if request.path == new_item_path
+        = f.submit "出品する", class: "FormBlock__btn--market"
+      - else
+        = f.submit "更新する", class: "FormBlock__btn--market"
       = link_to 'もどる', :back, class: "FormBlock__btn--return"
   .FormBlock__rules
     禁止されている


### PR DESCRIPTION
# What
- 商品の詳細ページで、投稿者だけが編集ページに遷移できる
- 画像の差し替えは一枚ごとにできる
- 商品出品時とほぼ同じUIで編集できる
- 画像やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で、もれなく表示される
- エラーハンドリング(未)

# Why
商品出品後に情報を変更できる様にする。