### PR TITLE
【サーバサイド】商品情報編集

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -25,7 +25,7 @@ $(function(){
 
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
   lastIndex = $('.ImageBox__fileGroup:last').data('index');
-  fileIndex.splice(0, lastIndex);
+  fileIndex.splice(0, lastIndex + 1);
 
   $('.hidden-destroy').hide();
 
@@ -91,4 +91,9 @@ $(document).ready(function(){
   const salesProfit = Math.floor(price - salesCommission)
   $('#salesCommission').text(`¥${salesCommission}`);
   $('#salesProfit').text(`¥${salesProfit}`);
+
+  var count = $('.ImageBox__preview').length;
+  if (count >= 10) {
+    $('.ImageBox__inputLabel').hide();
+  }
 });

--- a/app/views/items/_itemForm.html.haml
+++ b/app/views/items/_itemForm.html.haml
@@ -9,7 +9,7 @@
         #ImageBox
           .ImageBox__show
             #previews
-              %label{for: "item_images_attributes_#{@item.images.count}_src", class: 'ImageBox__inputLabel', id: 'label-box-0'}
+              %label{for: "item_images_attributes_#{@item.images.count}_src", class: 'ImageBox__inputLabel', id: "label-box-#{@item.images.count}"}
                 .ImageBox__inputLabel--visible
                   = icon('fas', 'camera', class: "ImageBox__inputLabel--icon")
                   %p.ImageBox__inputLabel--hwToUp ファイルを選択


### PR DESCRIPTION
# What
- [x] 商品の詳細ページで、投稿者だけが編集ページに遷移できるようになっている
- [x] 画像の差し替えは一枚ごとにできる
- [x] 商品出品時とほぼ同じUIで編集機能が実装できている
- [x] 画像やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で、もれなく表示されるようになっている
- [ ] エラーハンドリングができている &larr; いまここ

# Why
商品出品後も商品情報を変えることができる。